### PR TITLE
contour/envoy health check

### DIFF
--- a/analyzers.yaml
+++ b/analyzers.yaml
@@ -73,4 +73,4 @@ spec:
         outcomes:
           - fail:
               when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
-              message: A Comtour pod, {{ .Name }}, is unhealthy with a status of {{ .Status.Reason }}. Restarting the pod may fix the issue.
+              message: A Contour pod, {{ .Name }}, is unhealthy with a status of {{ .Status.Reason }}. Restarting the pod may fix the issue.

--- a/analyzers.yaml
+++ b/analyzers.yaml
@@ -66,3 +66,11 @@ spec:
               message: "Not all nodes are online."
           - pass:
               message: "All nodes are online."
+    - clusterPodStatuses:
+        name: contour pods unhealthy
+        namespaces:
+          - projectcontour
+        outcomes:
+          - fail:
+              when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
+              message: Pod {{ .Namespace }}/{{ .Name }} is unhealthy with a status of {{ .Status.Reason }}.

--- a/analyzers.yaml
+++ b/analyzers.yaml
@@ -67,10 +67,10 @@ spec:
           - pass:
               message: "All nodes are online."
     - clusterPodStatuses:
-        name: contour pods unhealthy
+        checkName: contour pods unhealthy
         namespaces:
           - projectcontour
         outcomes:
           - fail:
               when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
-              message: Pod {{ .Namespace }}/{{ .Name }} is unhealthy with a status of {{ .Status.Reason }}.
+              message: A Comtour pod, {{ .Name }}, is unhealthy with a status of {{ .Status.Reason }}. Restarting the pod may fix the issue.


### PR DESCRIPTION
fail if any pods in the projectcontour namespace are not healthy