### PR TITLE
added analyzer to check if NFS client package is missing

### DIFF
--- a/analyzers.yaml
+++ b/analyzers.yaml
@@ -74,3 +74,15 @@ spec:
           - fail:
               when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
               message: A Contour pod, {{ .Name }}, is unhealthy with a status of {{ .Status.Reason }}. Restarting the pod may fix the issue.
+    - textAnalyze:
+        checkName: NFS Client Package
+        fileName: cluster-resources/events/*.json
+        regex: 'bad option; for several filesystems \(e\.g\. nfs, cifs\) you might need a \/sbin\/mount\..+type.+ helper program\.'
+        outcomes:
+          - fail:
+              when: "true"
+              message: "NFS client is not installed. Refer to [documentation](https://docs.replicated.com/enterprise/snapshots-configuring-nfs) for steps on how to configure NFS snapshots."
+              uri: "https://docs.replicated.com/enterprise/snapshots-configuring-nfs"
+          - pass:
+              when: "false"
+              message: "NFS client is installed."


### PR DESCRIPTION
This analyzer will check all files matching `cluster-resources/events/*.json` for the message indicating that an NFS client is not installed on the host.  Ideally, this would just check `cluster-resources/events/<kots namespace>.json`, but I am not sure if this is possible.  Without limiting the check to the desired namespace, the user will end up with pass outcomes for the other namespaces (see below).  These are hidden by default in the admin console UI unless the user un-checks "Only show errors and warnings".

![nfs-client-analyzer](https://user-images.githubusercontent.com/17422963/161351356-3a99516f-5abb-4699-ac45-ae63833fa824.png)

You can run the CLI support bundle command using the `--namespace=<kots namespace>` flag to scope the request to the desired namespace, which will result in only one outcome for this analyzer, but this will limit the rest of the support bundle to this namespace, which may impact other analyzers.