### PR TITLE
Update default.yaml - Add Weave analyzer

### DIFF
--- a/in-cluster/default.yaml
+++ b/in-cluster/default.yaml
@@ -259,7 +259,7 @@ spec:
           - pass:
               message: Weave is ready
         regex: '"Ready": true'
-     - textAnalyze:
+    - textAnalyze:
         checkName: Weave IP Allocation
         exclude: ""
         ignoreIfNoFiles: true

--- a/in-cluster/default.yaml
+++ b/in-cluster/default.yaml
@@ -259,6 +259,17 @@ spec:
           - pass:
               message: Weave is ready
         regex: '"Ready": true'
+     - textAnalyze:
+        checkName: Weave IP Allocation
+        exclude: ""
+        ignoreIfNoFiles: true
+        fileName: kots/kurl/weave/kube-system/weave-net-*/weave-report-stdout.txt
+        outcomes:
+          - fail:
+              message: IP Allocation issues detected. Please run `rm /var/lib/weave/weave-netdata.db && reboot` on each node to resolve this.
+          - pass:
+              message: Weave is ready, there are no IP allocation issues.
+        regex: '"IP Allocation was seeded by different peers": false'
     - textAnalyze:
         checkName: Inter-pod Networking
         exclude: ""


### PR DESCRIPTION
We want to trigger an advised workaround once a known Weave error has been found. The originating public facing issue for this is: https://github.com/weaveworks/weave/blob/master/site/tasks/ipam/troubleshooting-ipam.md?rgh-link-date=2022-03-04T18%3A34%3A26Z#seeded-by-different-peers.

By adding a text analyzer that checks if the error `IP Allocation was seeded by different peers` is present, We can immediately offer a workaround to resolve the issue for the user.