### PR TITLE
Update README.md - typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Troubleshoot specs for using when running with `support-bundle`.
 
 `host`: Host Collectors and Analyzers to troubleshoot a kURL cluster. Useful when you need to gather information that isn't available with `in-cluster` collectors or if Kubernetes is offline. When run these will generate a support bundle with host level information about the host where the binary was executed.
 
-`in-cluster`: Standard Collectors and Analyzers that can be used to retreive information from a Kubernetes cluster
+`in-cluster`: Standard Collectors and Analyzers that can be used to retrieve information from a Kubernetes cluster


### PR DESCRIPTION
Fixed a typo: `retreive` -> `retrieve`