### PR TITLE
get a report of large files and dirs from host

### DIFF
--- a/host/resource-contention.yaml
+++ b/host/resource-contention.yaml
@@ -20,6 +20,10 @@ spec:
         command: "df"
         args: ["-h"]
     - run:
+        collectorName: "large-files"
+        command: "du"
+        args: ["-Shax", "/", "--exclude", "/proc", "|", "sort", "-rh", "|", "head", "-20"]
+    - run:
         collectorName: "iostat"
         command: "iostat"
         args: []

--- a/host/resource-contention.yaml
+++ b/host/resource-contention.yaml
@@ -20,9 +20,9 @@ spec:
         command: "df"
         args: ["-h"]
     - run:
-        collectorName: "large-files"
-        command: "du"
-        args: ["-Shax", "/", "--exclude", "/proc", "|", "sort", "-rh", "|", "head", "-20"]
+        collectorName: "du-root"
+        command: "sh"
+        args: ["-c", "du -Shax / --exclude /proc | sort -rh | head -20"]
     - run:
         collectorName: "iostat"
         command: "iostat"


### PR DESCRIPTION
```
3.4G    /var/lib/kurl/assets
1.3G    /var/lib/kurl/assets/rook-1.5.9.tar.gz
1.1G    /var/log/apiserver
897M    /var/lib/kurl/assets/kubernetes-1.19.16.tar.gz
812M    /var/lib/kurl/assets/docker-20.10.5.tar.gz
723M    /var/lib/snapd/snaps
683M    /usr/bin
...
```