### PR TITLE
increase journalctl collection to 7 days

### DIFF
--- a/host/cluster-down.yaml
+++ b/host/cluster-down.yaml
@@ -122,19 +122,19 @@ spec:
     - run:
         collectorName: "journalctl-containerd"
         command: "journalctl"
-        args: ["-u", "containerd", "--no-pager", "-S", "1 day ago"]
+        args: ["-u", "containerd", "--no-pager", "-S", "7 days ago"]
     - run:
         collectorName: "journalctl-kubelet"
         command: "journalctl"
-        args: ["-u", "kubelet", "--no-pager", "-S", "1 day ago"]
+        args: ["-u", "kubelet", "--no-pager", "-S", "7 days ago"]
     - run:
         collectorName: "journalctl-docker"
         command: "journalctl"
-        args: ["-u", "docker", "--no-pager", "-S", "1 day ago"]
+        args: ["-u", "docker", "--no-pager", "-S", "7 days ago"]
     - run:
         collectorName: "journalctl-dmesg"
         command: "journalctl"
-        args: ["--dmesg", "--no-pager", "-S", "1 day ago"]
+        args: ["--dmesg", "--no-pager", "-S", "7 days ago"]
   hostAnalyzers:
     - certificate:
         collectorName: k8s-api-keypair


### PR DESCRIPTION
I don't think 24 hours is enough time - sometimes we get a case, and it might be 24 hours before we get a response from "please run this host collector" and the important time window may have passed.  I might even prefer not using `--since` option at all and defaulting to collecting everything present in journald at the time.  But 7 might be a good compromise