### PR TITLE
Add netstat port list to cluster-down spec

### DIFF
--- a/host/cluster-down.yaml
+++ b/host/cluster-down.yaml
@@ -117,6 +117,10 @@ spec:
         collectorName: "ipvsadm"
         command: "ipvsadm"
         args: ["-l", "-n"]
+    - run:
+        collectorName: "netstat-ports"
+        command: "netstat"
+        args: ["-t", "-u", "-l", "-p", "-n"]
     # Systemctl service statuses for CRI, Kubelet, and Firewall
     - run:
         collectorName: "systemctl-firewalld-status"


### PR DESCRIPTION
A fair few times when we get a cluster-down support-bundle there are messages about the apiserver not responding. it would be nice to confirm:

1. what port the apiserver is listening on
2. if it's listening at all

without having to ask for another support bundle or manual commands. 