### PR TITLE
fix: curl k8s api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 *.tar.gz
 .pre-commit-config.yaml
+.idea/

--- a/host/cluster-down.yaml
+++ b/host/cluster-down.yaml
@@ -51,7 +51,7 @@ spec:
     - http:
         collectorName: curl-k8s-api-6443
         get:
-          url: https://localhost:6443
+          url: https://localhost:6443/healthz
           insecureSkipVerify: true
     - http:
         collectorName: curl-etcd-api-2379
@@ -366,12 +366,12 @@ spec:
         outcomes:
           - warn:
               when: "error"
-              message: Error connecting to https://localhost:6443/healthz
+              message: Unable to curl https://localhost:6443/healthz. Please, run `curl -k https://localhost:6443/healthz` to check further information.
           - pass:
               when: "statusCode == 200"
-              message: Connected to https://localhost:6443/healthz
+              message: curl -k https://localhost:6443/healthz returned HTTP CODE response 200.
           - warn:
-              message: "Unexpected response"
+              message: "Unexpected response. HTTP CODE response is not 200. Please, run `curl -ki https://localhost:6443/healthz` to check further information."
     - http:
         checkName: curl-etcd-api-2379
         collectorName: curl-etcd-api-2379


### PR DESCRIPTION
## Description 

Fix the endpoint that should be used. 
Also, improved the message to let us know what check was done. 

See:

<img width="1237" alt="Screenshot 2023-01-18 at 15 31 52" src="https://user-images.githubusercontent.com/7708031/213214836-99ca2d40-8a35-426c-90f0-d8be647dd634.png">

Partial fix to: https://github.com/replicatedhq/troubleshoot-specs/issues/34
