### PR TITLE
Collect contour pod logs

### DIFF
--- a/in-cluster/default-kurl.yaml
+++ b/in-cluster/default-kurl.yaml
@@ -189,6 +189,10 @@ spec:
         image: alpine
         imagePullPolicy: IfNotPresent
         timeout: 5m
+    - logs:
+        collectorName: projectcontour-logs
+        namespace: projectcontour
+        name: projectcontour/logs
   analyzers:
     - containerRuntime:
         outcomes:

--- a/in-cluster/default.yaml
+++ b/in-cluster/default.yaml
@@ -89,6 +89,10 @@ spec:
         name: kots/rqlite/logs
         selector:
           - app=kotsadm-rqlite
+    - logs:
+        collectorName: projectcontour-logs
+        namespace: projectcontour
+        name: projectcontour/logs
     - runPod:
         name: rqlite-status
         namespace: default


### PR DESCRIPTION
For cases where a user hosts their application behind contour, collected logs would help diagnose problems.