### PR TITLE
add check for know issue scenario

### DIFF
--- a/in-cluster/default-kurl.yaml
+++ b/in-cluster/default-kurl.yaml
@@ -350,4 +350,4 @@ spec:
               message: "If you have been removing and adding nodes then, you might want ensure that you are not facing the scenario described in the community topic: https://community.replicated.com/t/1099"
           - pass:
               when: "false"
-              message: "You are not using a Rook versions < 1.4 or your Ceph status is OK"
+              message: "You are not using a Rook versions < 1.4 and/or your Ceph status is OK"

--- a/in-cluster/default-kurl.yaml
+++ b/in-cluster/default-kurl.yaml
@@ -338,3 +338,16 @@ spec:
           - pass:
               when: "false"
               message: "Minio Disk Ok"
+    - textAnalyze:
+        checkName: KnowIssue with Rook < 1.4
+        exclude: ""
+        ignoreIfNoFiless: true
+        fileName: /ceph/status.json
+        regex: '\"ceph_release\": \"nautilus\"|\"status\": \"HEALTH_WARN\"'
+        outcomes:
+          - fail:
+              when: "true"
+              message: "If you have been removing and adding nodes then, you might want ensure that you are not facing the scenario described in the community topic: https://community.replicated.com/t/managing-nodes-when-the-previous-rook-version-is-in-use-might-leave-ceph-in-an-unhealthy-state-where-mon-pods-are-not-rescheduled/1099/1"
+          - pass:
+              when: "false"
+              message: "You are not using a Rook versions < 1.4 or your Ceph status is OK"

--- a/in-cluster/default-kurl.yaml
+++ b/in-cluster/default-kurl.yaml
@@ -339,15 +339,15 @@ spec:
               when: "false"
               message: "Minio Disk Ok"
     - textAnalyze:
-        checkName: KnowIssue with Rook < 1.4
+        checkName: Known issue with Rook < 1.4
         exclude: ""
-        ignoreIfNoFiless: true
+        ignoreIfNoFiles: true
         fileName: /ceph/status.json
         regex: '\"ceph_release\": \"nautilus\"|\"status\": \"HEALTH_WARN\"'
         outcomes:
           - fail:
               when: "true"
-              message: "If you have been removing and adding nodes then, you might want ensure that you are not facing the scenario described in the community topic: https://community.replicated.com/t/managing-nodes-when-the-previous-rook-version-is-in-use-might-leave-ceph-in-an-unhealthy-state-where-mon-pods-are-not-rescheduled/1099/1"
+              message: "If you have been removing and adding nodes then, you might want ensure that you are not facing the scenario described in the community topic: https://community.replicated.com/t/1099"
           - pass:
               when: "false"
               message: "You are not using a Rook versions < 1.4 or your Ceph status is OK"


### PR DESCRIPTION
## Description

Add check for know issue scenario to share the community topic with the workaround: https://community.replicated.com/t/managing-nodes-when-the-previous-rook-version-is-in-use-might-leave-ceph-in-an-unhealthy-state-where-mon-pods-are-not-rescheduled/1099

Related to: [sc-57227]

![Screenshot 2023-02-01 at 10 18 31](https://user-images.githubusercontent.com/7708031/216016444-a51a3448-a2f1-4e3f-aa90-2abee705fabc.png)

