### PR TITLE
Health check replicated.app

### DIFF
--- a/in-cluster/default-kurl.yaml
+++ b/in-cluster/default-kurl.yaml
@@ -231,7 +231,7 @@ spec:
     - http:
         collectorName: replicated.app-health-check
         get:
-          url: https://replicated.app/
+          url: https://replicated.app/healthz
   analyzers:
     - containerRuntime:
         outcomes:
@@ -374,7 +374,7 @@ spec:
         outcomes:
           - fail:
               when: "false"
-              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is an airgapped environment, please check your proxy settings.
+              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is locked down environment, please check your proxy settings.
               uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
           - pass:
               when: "true"

--- a/in-cluster/default-kurl.yaml
+++ b/in-cluster/default-kurl.yaml
@@ -228,6 +228,10 @@ spec:
         collectorName: projectcontour-logs
         namespace: projectcontour
         name: projectcontour/logs
+    - http:
+        collectorName: replicated.app-health-check
+        get:
+          url: https://replicated.app/
   analyzers:
     - containerRuntime:
         outcomes:
@@ -362,3 +366,16 @@ spec:
           - pass:
               when: "false"
               message: "Rook filesystem consistency ok"
+    - jsonCompare:
+        checkName: https://replicated.app host health check
+        fileName: replicated.app-health-check.json
+        path: "response.status"
+        value: "200"
+        outcomes:
+          - fail:
+              when: "false"
+              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is an airgapped environment, please check your proxy settings.
+              uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
+          - pass:
+              when: "true"
+              message: https://replicated.app host is healthy

--- a/in-cluster/default.yaml
+++ b/in-cluster/default.yaml
@@ -110,7 +110,7 @@ spec:
     - http:
         collectorName: replicated.app-health-check
         get:
-          url: https://replicated.app/
+          url: https://replicated.app/healthz
   analyzers:
     - containerRuntime:
         outcomes:
@@ -155,7 +155,7 @@ spec:
         outcomes:
           - fail:
               when: "false"
-              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is an airgapped environment, please check your proxy settings.
+              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is locked down environment, please check your proxy settings.
               uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
           - pass:
               when: "true"

--- a/in-cluster/default.yaml
+++ b/in-cluster/default.yaml
@@ -107,6 +107,10 @@ spec:
         name: kotsadm-replicated-registry # NOTE: this will not live under the kots/ directory like other collectors
         includeValue: false
         key: .dockerconfigjson
+    - http:
+        collectorName: replicated.app-health-check
+        get:
+          url: https://replicated.app/
   analyzers:
     - containerRuntime:
         outcomes:
@@ -143,3 +147,16 @@ spec:
           - fail:
               when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
               message: A Contour pod, {{ .Name }}, is unhealthy with a status of {{ .Status.Reason }}. Restarting the pod may fix the issue.
+    - jsonCompare:
+        checkName: https://replicated.app host health check
+        fileName: replicated.app-health-check.json
+        path: "response.status"
+        value: "200"
+        outcomes:
+          - fail:
+              when: "false"
+              message: https://replicated.app is unhealthy. License and software update checks from replicated will fail. If this is an airgapped environment, please check your proxy settings.
+              uri: https://kurl.sh/docs/install-with-kurl/proxy-installs
+          - pass:
+              when: "true"
+              message: https://replicated.app host is healthy


### PR DESCRIPTION
Health check collector and analyser to ensure https://replicated.app is healthy.

Fixes: https://github.com/replicatedhq/troubleshoot-specs/issues/59