### PR TITLE
collect apiserver audit logs

### DIFF
--- a/host/cluster-down.yaml
+++ b/host/cluster-down.yaml
@@ -5,6 +5,21 @@ metadata:
   name: cluster-down
 spec:
   uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/host/cluster-down.yaml
+  collectors:
+    # kURL Logs
+    - copyFromHost:
+        collectorName: "copy kURL logs"
+        image: busybox:1
+        hostPath: "/var/log/kurl/"
+        name: "logs"
+        extractArchive: true
+    # Kuberenets apiserver audit logs
+    - copyFromHost:
+        collectorName: "copy apiserver audit logs"
+        image: busybox:1
+        hostPath: "/var/log/apiserver/"
+        name: "logs"
+        extractArchive: true
   hostCollectors:
     # System Info Collectors
     - blockDevices: {}

--- a/in-cluster/default-kurl.yaml
+++ b/in-cluster/default-kurl.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   collectors:
     - copyFromHost:
+        collectorName: "copy apiserver audit logs"
+        image: busybox:1
+        hostPath: "/var/log/apiserver/"
+        name: "logs"
+        extractArchive: true
+    - copyFromHost:
         collectorName: "copy kURL logs"
         image: busybox:1
         hostPath: "/var/log/kurl/"


### PR DESCRIPTION
Collects the audit logs in `/var/log/apiserver`:
```bash
$ ls -l /var/log/apiserver/
total 1055924
-rw-r--r-- 1 root root 104857128 Mar 28 02:19 k8s-audit-2023-03-28T02-19-10.432.log
-rw-r--r-- 1 root root 104857027 Mar 28 03:55 k8s-audit-2023-03-28T03-55-55.070.log
-rw-r--r-- 1 root root 104857459 Mar 28 05:32 k8s-audit-2023-03-28T05-32-35.812.log
-rw-r--r-- 1 root root 104857199 Mar 28 07:09 k8s-audit-2023-03-28T07-09-18.354.log
-rw-r--r-- 1 root root 104857300 Mar 28 08:45 k8s-audit-2023-03-28T08-45-56.271.log
-rw-r--r-- 1 root root 104857136 Mar 28 10:22 k8s-audit-2023-03-28T10-22-34.252.log
-rw-r--r-- 1 root root 104857182 Mar 28 11:59 k8s-audit-2023-03-28T11-59-15.334.log
-rw-r--r-- 1 root root 104857465 Mar 28 13:35 k8s-audit-2023-03-28T13-35-50.325.log
-rw-r--r-- 1 root root 104857002 Mar 28 15:12 k8s-audit-2023-03-28T15-12-28.532.log
-rw-r--r-- 1 root root 104856981 Mar 28 16:48 k8s-audit-2023-03-28T16-48-36.748.log
-rw-r--r-- 1 root root  32650363 Mar 28 17:18 k8s-audit.log
```