### PR TITLE
Collect /etc/resolv.conf inside a pod

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -388,6 +388,14 @@ spec:
         collectorName: "localhost-ips"
         command: "sh"
         args: ["-c", "host localhost"]
+    - runPod:
+        name: resolv.conf
+        podSpec:
+          containers:
+            - name: resolv-conf
+              image: alpine
+              command: ["sh", "-c", "cat /etc/resolv.conf"]
+          restartPolicy: Never
   hostAnalyzers:
     - certificate:
         collectorName: k8s-api-keypair


### PR DESCRIPTION
This should help see what nameservers are used to resolve DNS queries inside a cluster