### PR TITLE
chore: Collect route table using 'ip route' command

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -144,6 +144,10 @@ spec:
         command: "netstat"
         args: ["-r", "-n"]
     - run:
+        collectorName: "ip-route-table"
+        command: "ip"
+        args: ["route"]
+    - run:
         collectorName: "sysctl"
         command: "sysctl"
         args: ["-a"]


### PR DESCRIPTION
Not all systems will have 'netstat' which the current default host collector spec uses to collect the route table information