### PR TITLE
Analyser to check if SELinux is exabled

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -87,6 +87,7 @@ spec:
         collectorName: "iostat"
         command: "iostat"
         args: ["-x"]
+    # SELinux status
     - run:
         collectorName: "sestatus"
         command: "sestatus"
@@ -151,9 +152,6 @@ spec:
         collectorName: "sysctl"
         command: "sysctl"
         args: ["-a"]
-    - copy:
-        collectorName: selinux-config
-        path: /etc/selinux/config
     # Systemctl service statuses for CRI, Kubelet, and Firewall
     - run:
         collectorName: "systemctl-firewalld-status"
@@ -744,8 +742,8 @@ spec:
               message: "'localhost' resolves to 127.0.0.1 ip address"
     - textAnalyze:
         checkName: Check if SELinux is enabled
-        fileName: host-collectors/selinux-config/config
-        regex: '(?m)^SELINUX=enforcing'
+        fileName: host-collectors/run-host/sestatus.txt
+        regex: '(?m)^Current mode:\s+enforcing'
         ignoreIfNoFiles: true
         outcomes:
           - fail:

--- a/host/default.yaml
+++ b/host/default.yaml
@@ -151,6 +151,9 @@ spec:
         collectorName: "sysctl"
         command: "sysctl"
         args: ["-a"]
+    - copy:
+        collectorName: selinux-config
+        path: /etc/selinux/config
     # Systemctl service statuses for CRI, Kubelet, and Firewall
     - run:
         collectorName: "systemctl-firewalld-status"
@@ -739,3 +742,15 @@ spec:
           - pass:
               when: "true"
               message: "'localhost' resolves to 127.0.0.1 ip address"
+    - textAnalyze:
+        checkName: Check if SELinux is enabled
+        fileName: host-collectors/selinux-config/config
+        regex: 'SELINUX=enforcing'
+        ignoreIfNoFiles: true
+        outcomes:
+          - fail:
+              when: "true"
+              message: "SELinux is enabled when it should be disabled for kubernetes to work properly"
+          - pass:
+              when: "false"
+              message: "SELinux is disabled as expected"

--- a/host/default.yaml
+++ b/host/default.yaml
@@ -745,7 +745,7 @@ spec:
     - textAnalyze:
         checkName: Check if SELinux is enabled
         fileName: host-collectors/selinux-config/config
-        regex: 'SELINUX=enforcing'
+        regex: '(?m)^SELINUX=enforcing'
         ignoreIfNoFiles: true
         outcomes:
           - fail:


### PR DESCRIPTION
Analyser to check if SELinux is enabled in a system. kURL installer disables it during installation but it would be good to know if it got reenabled after installation e.g by some security tooling/automation or a sysadmin