### PR TITLE
 Add fireeye xagt to list of security tools

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -415,7 +415,7 @@ spec:
     - run:
         collectorName: "ps-detect-antivirus-and-security-tools"
         command: "sh"
-        args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio' | grep -v grep"]
+        args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt' | grep -v grep"]
     - filesystemPerformance:
         collectorName: filesystem-latency-two-minute-benchmark
         timeout: 2m
@@ -796,7 +796,7 @@ spec:
     - textAnalyze:
         checkName: "Detect Threat Management and Network Security Tools"
         fileName: host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt
-        regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio)\b'
+        regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt)\b'
         ignoreIfNoFiles: true
         outcomes:
           - fail:


### PR DESCRIPTION
`xagt` has a nasty habit of locking iptables and preventing kube-proxy from injecting it's rules. 