### PR TITLE
Feature: Print runPod collector name in failed error logs

### DIFF
--- a/in-cluster/default.yaml
+++ b/in-cluster/default.yaml
@@ -6,6 +6,7 @@ spec:
   uri: https://raw.githubusercontent.com/replicatedhq/troubleshoot-specs/main/in-cluster/default.yaml
   collectors:
     - runPod:
+        collectorName: "ekco-resources"
         name: ekco-resources
         namespace: kurl
         podSpec:
@@ -254,6 +255,7 @@ spec:
         namespace: projectcontour
         name: projectcontour/logs
     - runPod:
+        collectorName: "rqlite-status"
         name: rqlite-status
         namespace: default
         podSpec:
@@ -263,6 +265,7 @@ spec:
               command: ["wget"]
               args: ["-q", "-T", "5", "http://kotsadm-rqlite:4001/status?pretty", "-O-"]
     - runPod:
+        collectorName: "rqlite-nodes"
         name: rqlite-nodes
         namespace: default
         podSpec:


### PR DESCRIPTION
As previously it was difficult to find out which collector task is failing for run pod, so the requirement was to have the collector name print (as below) in the error logs. See story #[109476](https://app.shortcut.com/replicated/story/109476/troubleshoot-print-collector-name-when-a-collector-fails)

<img width="797" alt="Screenshot 2024-08-23 at 7 25 58 PM" src="https://github.com/user-attachments/assets/b5bb2a6d-edde-4e6a-bf11-7b9dda163f29">
