### PR TITLE
fix(spec): remove non-exists host collector in default spec

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -461,14 +461,6 @@ spec:
         collectorName: "localhost-ips"
         command: "sh"
         args: ["-c", "host localhost"]
-    - runPod:
-        name: resolv.conf
-        podSpec:
-          containers:
-            - name: resolv-conf
-              image: alpine
-              command: ["sh", "-c", "cat /etc/resolv.conf"]
-          restartPolicy: Never
   hostAnalyzers:
     - certificate:
         collectorName: k8s-api-keypair


### PR DESCRIPTION
since runPod does not exist in host collector and we have run cat resolv.conf, it should be deleted.
https://github.com/replicatedhq/troubleshoot-specs/blob/5abc9eb87437e5afe29315eec968b28359cabd3c/host/default.yaml#L151 existed