### PR TITLE
Add disk IO stats collectors

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -87,6 +87,14 @@ spec:
         collectorName: "iostat"
         command: "iostat"
         args: ["-x"]
+    - run:
+        collectorName: "pidstat-disk-io"
+        command: "pidstat"
+        args: ["d"]
+    - run:
+        collectorName: "iotop"
+        command: "iotop"
+        args: ["-n", "1", "-b"]
     # SELinux status
     - run:
         collectorName: "sestatus"


### PR DESCRIPTION
Add `pidstats` and `iotop` host collectors to collect information of disk IO usage