### PR TITLE
chore: Enable filesystem performance collector/analyser

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -460,7 +460,6 @@ spec:
         backgroundWriteIOPSJobs: 6
         backgroundReadIOPS: 50
         backgroundReadIOPSJobs: 1
-        exclude: true
     - run:
         collectorName: "localhost-ips"
         command: "sh"
@@ -742,7 +741,6 @@ spec:
               message: "Write latency is ok (p99 target < 10ms)"
           - warn:
               message: "Write latency is high. p99 target >= 10ms)"
-        exclude: true
   analyzers:
     - textAnalyze:
         checkName: Hostname Mismatch


### PR DESCRIPTION
The collector adds up to 2mins to the collection process. Ideally, this add about 10 more seconds

If `fio` takes 2mins to do its thing, the process gets interrupted by `support-bundle` process