### PR TITLE
chore: Only collect the latest k8s-audit API server log

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -377,7 +377,7 @@ spec:
     # to succeed it requires sudo privileges for the user
     - copy:
         collectorName: "apiserver-audit-logs"
-        path: /var/log/apiserver/k8s-audit*
+        path: /var/log/apiserver/k8s-audit.log
     # Collect kURL installer logs
     - copy:
         collectorName: "kurl-logs"


### PR DESCRIPTION
Collecting all k8s API server audit logs tend to generate large support bundles where audit logs account for `1GB` in size.  Not the entire audit history is always needed. This make it not ideal sending large bundles which need to be sent by customers to vendors, and then to Replicated.