### PR TITLE
chore: add Microsoft Defender Antivirus to the list of security tools

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -454,7 +454,7 @@ spec:
     - run:
         collectorName: "ps-detect-antivirus-and-security-tools"
         command: "sh"
-        args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon' | grep -v grep"]
+        args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp' | grep -v grep"]
     - filesystemPerformance:
         collectorName: filesystem-latency-two-minute-benchmark
         timeout: 2m


### PR DESCRIPTION
Ensure Microsoft Defender Antivirus security tool is detected by the support bundle analysis.