### PR TITLE
feat: add security tools host preflight

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -455,6 +455,12 @@ spec:
         collectorName: "ps-detect-antivirus-and-security-tools"
         command: "sh"
         args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp' | grep -v grep"]
+    - systemPackages:
+        collectorName: security-tools-packages
+        rhel:
+          - sdcss-kmod
+          - sdcss
+          - sdcss-scripts
     - filesystemPerformance:
         collectorName: filesystem-latency-two-minute-benchmark
         timeout: 2m
@@ -831,7 +837,7 @@ spec:
     - textAnalyze:
         checkName: "Detect Threat Management and Network Security Tools"
         fileName: host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt
-        regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon)\b'
+        regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp)\b'
         ignoreIfNoFiles: true
         outcomes:
           - fail:
@@ -840,3 +846,11 @@ spec:
           - pass:
               when: "false"
               message: "No Antivirus or Network Security tools detected."
+    - systemPackages:
+        collectorName: security-tools-packages
+        outcomes:
+          - fail:
+              when: '{{ .IsInstalled }}'
+              message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation.
+          - pass:
+              message: Package {{ .Name }} is not installed

--- a/host/security-tools-preflights.yaml
+++ b/host/security-tools-preflights.yaml
@@ -24,7 +24,7 @@ spec:
         outcomes:
           - fail:
               when: "true"
-              message: "Antivirus or network security tools detected. These tools can interfere with kubernetes operation. Check 'host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt' in the preflight archive for the list of detected tools."
+              message: "Antivirus or network security tools detected. These tools can interfere with kubernetes operation. Check 'host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt' in the preflight archive for the list of detected tools. Ensure the tools are either disabled or configured to not interfere with kubernetes operation."
           - pass:
               when: "false"
               message: "No Antivirus or Network Security tools detected."
@@ -34,6 +34,6 @@ spec:
         outcomes:
           - fail:
               when: '{{ .IsInstalled }}'
-              message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation.
+              message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation. Ensure the tool is either disabled or configured to not interfere with kubernetes operation.
           - pass:
               message: Package {{ .Name }} is not installed

--- a/host/security-tools-preflights.yaml
+++ b/host/security-tools-preflights.yaml
@@ -2,11 +2,11 @@
 apiVersion: troubleshoot.sh/v1beta2
 kind: HostPreflight
 metadata:
-  name: security-tools-preflights
+  name: security-tools
 spec:
   collectors:
     - systemPackages:
-        collectorName: system-packages
+        collectorName: security-tools-packages
         rhel:
           - sdcss-kmod
           - sdcss
@@ -17,21 +17,22 @@ spec:
         args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp' | grep -v grep"]
   analyzers:
     - textAnalyze:
-        checkName: "Detected Threat Management and Network Security Tools"
+        checkName: "Detected Threat Management and Network Security Agent"
         fileName: host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt
-        regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon)\b'
+        regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp)\b'
         ignoreIfNoFiles: true
         outcomes:
-          - warn:
+          - fail:
               when: "true"
-              message: "Antivirus or Network Security tools detected. These tools can interfere with kubernetes operation."
+              message: "Antivirus or network security tools detected. These tools can interfere with kubernetes operation. Check 'host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt' in the preflight archive for the list of detected tools."
           - pass:
               when: "false"
               message: "No Antivirus or Network Security tools detected."
     - systemPackages:
-        collectorName: system-packages
+        checkName: "Detected Security Packages"
+        collectorName: security-tools-packages
         outcomes:
-          - warn:
+          - fail:
               when: '{{ .IsInstalled }}'
               message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation.
           - pass:

--- a/host/security-tools-preflights.yaml
+++ b/host/security-tools-preflights.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: security-tools-preflights
+spec:
+  collectors:
+    - systemPackages:
+        collectorName: system-packages
+        rhel:
+          - sdcss-kmod
+          - sdcss
+          - sdcss-scripts
+    - run:
+        collectorName: "ps-detect-antivirus-and-security-tools"
+        command: "sh"
+        args: [-c, "ps -ef | grep -E 'clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp' | grep -v grep"]
+  analyzers:
+    - textAnalyze:
+        checkName: "Detected Threat Management and Network Security Tools"
+        fileName: host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt
+        regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon)\b'
+        ignoreIfNoFiles: true
+        outcomes:
+          - warn:
+              when: "true"
+              message: "Antivirus or Network Security tools detected. These tools can interfere with kubernetes operation."
+          - pass:
+              when: "false"
+              message: "No Antivirus or Network Security tools detected."
+    - systemPackages:
+        collectorName: system-packages
+        outcomes:
+          - warn:
+              when: '{{ .IsInstalled }}'
+              message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation.
+          - pass:
+              message: Package {{ .Name }} is not installed


### PR DESCRIPTION
### Enhancements to security tools detection:

* **Addition of `systemPackages` collector**: Introduced a new collector to identify specific security-related packages installed on `rhel` systems, such as `sdcss-kmod`, `sdcss`, and `sdcss-scripts`. [[1]](diffhunk://#diff-3fd0544bc822b0283dafcd0a7947e2a6fc35db9512cddc531280cd8fca6ed4b5R458-R463) [[2]](diffhunk://#diff-0ce4838bd81fb28acf149e02e17b76c561c82133410f672791ba677c1afe2adeR1-R39)

* **Refined regex for detecting running processes**: Updated the regex pattern in the `textAnalyze` analyzer to include `mdatp` for detecting running antivirus and network security tools. [[1]](diffhunk://#diff-3fd0544bc822b0283dafcd0a7947e2a6fc35db9512cddc531280cd8fca6ed4b5L834-R840) [[2]](diffhunk://#diff-0ce4838bd81fb28acf149e02e17b76c561c82133410f672791ba677c1afe2adeR1-R39)

### New security tools host preflight:

* **System package analyzer**: Added an analyzer to evaluate whether specific security packages are installed, with outcomes indicating whether they may interfere with Kubernetes operations. [[1]](diffhunk://#diff-3fd0544bc822b0283dafcd0a7947e2a6fc35db9512cddc531280cd8fca6ed4b5R849-R856) [[2]](diffhunk://#diff-0ce4838bd81fb28acf149e02e17b76c561c82133410f672791ba677c1afe2adeR1-R39)

* **Preflight configuration for security tools**: Created a new preflight YAML configuration (`host/security-tools-preflights.yaml`) to consolidate collectors and analyzers for detecting both running processes and installed packages related to security tools.