### PR TITLE
chore: add ubuntu packages to security-tools-preflights

### DIFF
--- a/host/security-tools-preflights.yaml
+++ b/host/security-tools-preflights.yaml
@@ -7,6 +7,10 @@ spec:
   collectors:
     - systemPackages:
         collectorName: security-tools-packages
+        ubuntu:
+          - sdcss-kmod
+          - sdcss
+          - sdcss-scripts
         rhel:
           - sdcss-kmod
           - sdcss


### PR DESCRIPTION
Add ubuntu packages to security-tools-preflights in tools host preflights