### PR TITLE
chore: collect network interface statistics

### DIFF
--- a/host/default.yaml
+++ b/host/default.yaml
@@ -478,6 +478,14 @@ spec:
         collectorName: "localhost-ips"
         command: "sh"
         args: ["-c", "host localhost"]
+    - run:
+        collectorName: "ip-address-stats"
+        command: "ip"
+        args: ["-s", "-s", "address"]
+    - run:
+        collectorName: "lspci"
+        command: "lspci"
+        args: ["-vvv", "-D"]
   hostAnalyzers:
     - certificate:
         collectorName: k8s-api-keypair

--- a/host/default.yaml
+++ b/host/default.yaml
@@ -483,9 +483,44 @@ spec:
         command: "ip"
         args: ["-s", "-s", "address"]
     - run:
-        collectorName: "lspci"
-        command: "lspci"
-        args: ["-vvv", "-D"]
+        collectorName: "ethool-info"
+        command: "sh"
+        args:
+          - -c
+          - >
+            interfaces=$(ls /sys/class/net);
+            for iface in $interfaces; do
+              echo "==============================================";
+              echo "Interface: $iface";
+              echo "==============================================";
+
+              echo
+              echo "--- Basic Info ---"
+              ethtool "$iface"
+
+              echo
+              echo "--- Features (Offloads) ---"
+              ethtool -k "$iface"
+
+              echo
+              echo "--- Pause Parameters ---"
+              ethtool -a "$iface"
+
+              echo
+              echo "--- Ring Parameters ---"
+              ethtool -g "$iface"
+
+              echo
+              echo "--- Coalesce Settings ---"
+              ethtool -c "$iface"
+
+              echo
+              echo "--- Driver Info ---"
+              ethtool -i "$iface"
+
+              echo
+              echo
+            done
   hostAnalyzers:
     - certificate:
         collectorName: k8s-api-keypair


### PR DESCRIPTION
Collect output of `ip -s -s address`, `lspci -vvv -D` and `ethtool -(a|g|k|c|i) <interface>`

Example output
```
ip -s -s address | grep eth1: -A20
5: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 18:7b:b3:1e:04:60 brd ff:ff:ff:ff:ff:ff
    inet 10.0.0.161/24 metric 100 brd 10.0.0.255 scope global dynamic eth1
       valid_lft 41901sec preferred_lft 41901sec
    inet6 fe80::1a7b:b3ff:fe1e:460/64 scope link
       valid_lft forever preferred_lft forever
    RX:  bytes packets errors dropped  missed   mcast
    1371687222  171289      0       0       0       0
    RX errors:  length    crc   frame    fifo overrun
                     0      0       0       0       0
    TX:  bytes packets errors dropped carrier collsns
       7715477  100950      0       0       0       0
    TX errors: aborted   fifo  window heartbt transns
                     0      0       0       0       2
```

```
sudo lspci -vvv -D
0000:00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma] (rev 02)
        Subsystem: Red Hat, Inc. Qemu virtual machine
        Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV+ VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
        Status: Cap- 66MHz- UDF- FastB2B+ ParErr- DEVSEL=medium >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
        Latency: 0

0000:00:04.0 Ethernet controller: Red Hat, Inc. Virtio network device
        Subsystem: Red Hat, Inc. Virtio network device
        Physical Slot: 4
        Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV+ VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
        Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx+
        Latency: 0
        Interrupt: pin A routed to IRQ 10
        Region 0: I/O ports at c000 [size=64]
        Region 1: Memory at c0000000 (32-bit, non-prefetchable) [size=256]
        Capabilities: [80] MSI-X: Enable+ Count=9 Masked-
                Vector table: BAR=1 offset=00000008
                PBA: BAR=1 offset=00000000
        Kernel driver in use: virtio-pci
...
```