### PR TITLE
feat: additional preflight checks

### DIFF
--- a/host/infra-management-tools.yaml
+++ b/host/infra-management-tools.yaml
@@ -16,7 +16,7 @@ spec:
         regex: '\b(puppet|chef-client|cf-agent)\b'
         ignoreIfNoFiles: true
         outcomes:
-          - fail:
+          - warn:
               when: "true"
               message: "Infrastructure management tools detected. These tools can modify system configurations needed for kubernetes operation. Check 'host-collectors/run-host/ps-detect-infra-management-tools.txt' in the preflight archive for the list of detected tools. Ensure the tools are either disabled or configured to not interfere with configurations needed for kubernetes operation."
           - pass:

--- a/host/infra-management-tools.yaml
+++ b/host/infra-management-tools.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: infra-management-tools
+spec:
+  collectors:
+    - run:
+        collectorName: "ps-detect-infra-management-tools"
+        command: "sh"
+        args: [-c, "ps -ef | grep -E 'puppet|chef-client|cf-agent' | grep -v grep"]
+  analyzers:
+    - textAnalyze:
+        checkName: "Detected Infrastructure Management Tools"
+        fileName: host-collectors/run-host/ps-detect-infra-management-tools.txt
+        regex: '\b(puppet|chef-client|cf-agent)\b'
+        ignoreIfNoFiles: true
+        outcomes:
+          - fail:
+              when: "true"
+              message: "Infrastructure management tools detected. These tools can modify system configurations needed for kubernetes operation. Check 'host-collectors/run-host/ps-detect-infra-management-tools.txt' in the preflight archive for the list of detected tools. Ensure the tools are either disabled or configured to not interfere with configurations needed for kubernetes operation."
+          - pass:
+              when: "false"
+              message: "No Infrastructure Management tools detected."

--- a/host/security-tools-preflights.yaml
+++ b/host/security-tools-preflights.yaml
@@ -26,7 +26,7 @@ spec:
         regex: '\b(clamav|sophos|esets_daemon|fsav|symantec|mfend|ds_agent|kav|bdagent|s1agent|falcon|illumio|xagt|wdavdaemon|mdatp)\b'
         ignoreIfNoFiles: true
         outcomes:
-          - fail:
+          - warn:
               when: "true"
               message: "Antivirus or network security tools detected. These tools can interfere with kubernetes operation. Check 'host-collectors/run-host/ps-detect-antivirus-and-security-tools.txt' in the preflight archive for the list of detected tools. Ensure the tools are either disabled or configured to not interfere with kubernetes operation."
           - pass:
@@ -36,7 +36,7 @@ spec:
         checkName: "Detected Security Packages"
         collectorName: security-tools-packages
         outcomes:
-          - fail:
+          - warn:
               when: '{{ .IsInstalled }}'
               message: Package {{ .Name }} is installed. This tool can interfere with kubernetes operation. Ensure the tool is either disabled or configured to not interfere with kubernetes operation.
           - pass:

--- a/host/storage-checks.yaml
+++ b/host/storage-checks.yaml
@@ -1,0 +1,23 @@
+# This preflight checks the available storage space on the data directory.
+# Usage:
+#   DATA_DIR=/opt/data STORAGE=50Gi envsubst < storage-checks.yaml | sudo preflight - --interactive=false
+
+apiVersion: troubleshoot.sh/v1beta2
+kind: HostPreflight
+metadata:
+  name: storage-checks
+spec:
+  collectors:
+    - diskUsage:
+        collectorName: data-dir-disk-usage
+        path: $DATA_DIR
+  analyzers:
+    - diskUsage:
+        checkName: Data Directory Disk Space
+        collectorName: data-dir-disk-usage
+        outcomes:
+          - fail:
+              when: 'available < $STORAGE'
+              message: The filesystem at $DATA_DIR has less than $STORAGE of available storage space needed to for this installation.
+          - pass:
+              message: The filesystem at $DATA_DIR has sufficient available space

--- a/in-cluster/check-pod-limits.yaml
+++ b/in-cluster/check-pod-limits.yaml
@@ -1,0 +1,22 @@
+# This preflight checks the number of nodes in the cluster with 110 pods capacity.
+# Usage:
+#   POD_CAPACITY=110 MIN_NODES=3 envsubst < check-pod-limits.yaml | preflight -
+
+apiVersion: troubleshoot.sh/v1beta2
+kind: Preflight
+metadata:
+  name: check-pod-limits
+spec:
+  collectors:
+    - clusterResources: {}
+  analyzers:
+    - nodeResources:
+        checkName: Must have at least $MIN_NODES nodes in the cluster with $POD_CAPACITY pods capacity
+        filters:
+          podCapacity: "$POD_CAPACITY"
+        outcomes:
+          - fail:
+              when: "count() < $MIN_NODES"
+              message: This application requires at least $MIN_NODES nodes with $POD_CAPACITY pods capacity
+          - pass:
+              message: This cluster has enough nodes.


### PR DESCRIPTION
- Add a preflight spec that detects running infrastructure management tools in a VM. This spec is meant to warn users if any of the management tools are found so users can ensure the tools are configured not to interferer with configurations made for Embedded Cluster
- Add a storage check host preflight that uses environment variables to as template variables
- Add in-cluster preflight to check pod limits