### PR TITLE
Update lint workflow to Node 24 runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3


### PR DESCRIPTION
GitHub is deprecating Node 20 for GitHub Actions runtimes. This PR updates the lint workflow to use an action version that runs on Node 24.

Changes:
- `actions/checkout@v2` -> `actions/checkout@v7` (Node 24)

This resolves the "Node.js 20 is deprecated" warning seen in recent lint workflow runs.